### PR TITLE
DateTimeImmutable::createFromFormat()はPHP8以降ではnullを受け付けない

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,10 @@
         "phpunit/phpunit": "^9.5",
         "guzzlehttp/psr7": "^2.4",
         "php-http/message": "^1.13"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -8,7 +8,7 @@ use Psr\Log\LoggerInterface;
 
 class Config
 {
-    const VERSION = '1.0.0';
+    const VERSION = '1.0.2';
     const DEFAULT_API_BASE = 'https://prg.karaden.jp/api';
     const DEFALUT_API_VERSION = '2023-01-01';
 

--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -69,46 +69,46 @@ class Message extends Requestable
         return $this->getProperty('charged_count_per_sent');
     }
 
-    public function getScheduledAt(): DateTimeInterface
+    public function getScheduledAt(): ?DateTimeInterface
     {
         $scheduledAt = $this->getProperty('scheduled_at');
-        return DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $scheduledAt);
+        return $scheduledAt ? DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $scheduledAt) : null;
     }
 
-    public function getLimitedAt(): DateTimeInterface
+    public function getLimitedAt(): ?DateTimeInterface
     {
         $limitedAt = $this->getProperty("limited_at");
-        return DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $limitedAt);
+        return $limitedAt ? DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $limitedAt) : null;
     }
 
-    public function getSentAt(): DateTimeInterface
+    public function getSentAt(): ?DateTimeInterface
     {
         $sentAt = $this->getProperty("sent_at");
-        return DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $sentAt);
+        return $sentAt ? DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $sentAt) : null;
     }
 
-    public function getReceivedAt(): DateTimeInterface
+    public function getReceivedAt(): ?DateTimeInterface
     {
         $receivedAt = $this->getProperty('received_at');
-        return DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $receivedAt);
+        return $receivedAt ? DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $receivedAt) : null;
     }
 
-    public function getChargedAt(): DateTimeInterface
+    public function getChargedAt(): ?DateTimeInterface
     {
         $chargedAt = $this->getProperty('charged_at');
-        return DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $chargedAt);
+        return $chargedAt ? DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $chargedAt) : null;
     }
 
-    public function getCreatedAt(): DateTimeInterface
+    public function getCreatedAt(): ?DateTimeInterface
     {
         $createdAt = $this->getProperty('created_at');
-        return DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $createdAt);
+        return $createdAt ? DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $createdAt) : null;
     }
 
-    public function getUpdatedAt(): DateTimeInterface
+    public function getUpdatedAt(): ?DateTimeInterface
     {
         $updatedAt = $this->getProperty('updated_at');
-        return DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $updatedAt);
+        return $updatedAt ? DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $updatedAt) : null;
     }
 
     public static function create(MessageCreateParams $params, ?RequestOptions $requestOptions = null): Message

--- a/tests/Model/MessageTest.php
+++ b/tests/Model/MessageTest.php
@@ -250,88 +250,96 @@ class MessageTest extends TestCase
         $this->assertEquals($value, $message->getCarrier());
     }
 
+    public function dateProvider(): array
+    {
+        return [
+            ['2022-12-09T00:00:00+09:00'],
+            [null],
+        ];
+    }
+
     /**
      * @test
+     * @dataProvider dateProvider
      */
-    public function scheduledAtを出力できる()
+    public function scheduledAtを出力できる($value)
     {
-        $value = '2022-12-09T00:00:00+09:00';
         $message = new Message();
         $message->setProperty('scheduled_at', $value);
         
-        $this->assertEquals($value, $message->getScheduledAt()->format(DateTimeInterface::ATOM));
+        $this->assertEquals($value, $message->getScheduledAt() ? $message->getScheduledAt()->format(DateTimeInterface::ATOM) : null);
     }
 
     /**
      * @test
+     * @dataProvider dateProvider
      */
-    public function limitedAtを出力できる()
+    public function limitedAtを出力できる($value)
     {
-        $value = '2022-12-09T00:00:00+09:00';
         $message = new Message();
         $message->setProperty('limited_at', $value);
         
-        $this->assertEquals($value, $message->getLimitedAt()->format(DateTimeInterface::ATOM));
+        $this->assertEquals($value, $message->getLimitedAt() ? $message->getLimitedAt()->format(DateTimeInterface::ATOM) : null);
     }
 
     /**
      * @test
+     * @dataProvider dateProvider
      */
-    public function sentAtを出力できる()
+    public function sentAtを出力できる($value)
     {
-        $value = '2022-12-09T00:00:00+09:00';
         $message = new Message();
         $message->setProperty('sent_at', $value);
 
-        $this->assertEquals($value, $message->getSentAt()->format(DateTimeInterface::ATOM));
+        $this->assertEquals($value, $message->getSentAt() ? $message->getSentAt()->format(DateTimeInterface::ATOM) : null);
     }
 
     /**
      * @test
+     * @dataProvider dateProvider
      */
-    public function receivedAtを出力できる()
+    public function receivedAtを出力できる($value)
     {
-        $value = '2022-12-09T00:00:00+09:00';
         $message = new Message();
         $message->setProperty('received_at', $value);
 
-        $this->assertEquals($value, $message->getReceivedAt()->format(DateTimeInterface::ATOM));
+        $this->assertEquals($value, $message->getReceivedAt() ? $message->getReceivedAt()->format(DateTimeInterface::ATOM) : null);
     }
 
     /**
      * @test
+     * @dataProvider dateProvider
      */
-    public function chargedAtを出力できる()
+    public function chargedAtを出力できる($value)
     {
-        $value = '2022-12-09T00:00:00+09:00';
         $message = new Message();
         $message->setProperty('charged_at', $value);
 
-        $this->assertEquals($value, $message->getChargedAt()->format(DateTimeInterface::ATOM));
+        $this->assertEquals($value, $message->getChargedAt() ? $message->getChargedAt()->format(DateTimeInterface::ATOM) : null);
     }
 
     /**
      * @test
+     * @dataProvider dateProvider
      */
-    public function createdAtを出力できる()
+    public function createdAtを出力できる($value)
     {
-        $value = '2022-12-09T00:00:00+09:00';
         $message = new Message();
         $message->setProperty('created_at', $value);
 
-        $this->assertEquals($value, $message->getCreatedAt()->format(DateTimeInterface::ATOM));
+        $this->assertEquals($value, $message->getCreatedAt() ? $message->getCreatedAt()->format(DateTimeInterface::ATOM) : null);
     }
 
     /**
      * @test
+     * @dataProvider dateProvider
      */
-    public function updatedAtを出力できる()
+    public function updatedAtを出力できる($value)
     {
-        $value = '2022-12-09T00:00:00+09:00';
         $message = new Message();
         $message->setProperty('updated_at', $value);
 
-        $this->assertEquals($value, $message->getUpdatedAt()->format(DateTimeInterface::ATOM));
+        $this->assertEquals($value, $message->getUpdatedAt() ? $message->getUpdatedAt()->format(DateTimeInterface::ATOM) : null);
     }
 }
  


### PR DESCRIPTION
fix https://github.com/karaden-prg/karaden-prg-php/issues/4